### PR TITLE
:see_no_evil: fixed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,22 @@
-.vscode
+# Ignore VSCode folder
+.vscode/
+
+### Apple iOS ###
+.DS_Store
+*.DS_Store
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*__pycache__/
+*.py[cod]
+*$py.class
 *.sw[op]


### PR DESCRIPTION
Updated `.gitignore` now ignores:
1. Byte-compiled pycache folder
2. Mac `.DS_Store` folder
3. VSCode settings
4. Python `venv` 