### PR TITLE
fix: expected city list to set for loop bounds

### DIFF
--- a/src/cityreader/test_cityreader.py
+++ b/src/cityreader/test_cityreader.py
@@ -77,7 +77,7 @@ class CityreaderTests(unittest.TestCase):
     ]
     
   def test_cityreader_correctness(self):
-    for i in range(len(self.cities)):
+    for i in range(len(self.expected)):
       self.assertTrue(check_city(self.cities[i], self.expected[i]))
 
 


### PR DESCRIPTION
Fixes a false positive in the test case where if function `cityreader` outputs an empty list.