### PR TITLE
Fixed bug that let test pass on empty list, added pycache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 *.sw[op]
+__pycache__

--- a/src/cityreader/test_cityreader.py
+++ b/src/cityreader/test_cityreader.py
@@ -77,6 +77,7 @@ class CityreaderTests(unittest.TestCase):
     ]
     
   def test_cityreader_correctness(self):
+    self.assertEqual(len(self.cities), 60)
     for i in range(len(self.cities)):
       self.assertTrue(check_city(self.cities[i], self.expected[i]))
 


### PR DESCRIPTION
Checks length of cityreader output, will fail if list is empty or if first row of CSV was not skipped. Also added pycache folders to gitignore.